### PR TITLE
Add support for some Tiled features: class properties and object alignment

### DIFF
--- a/pytiled_parser/parsers/tmx/properties.py
+++ b/pytiled_parser/parsers/tmx/properties.py
@@ -2,7 +2,7 @@ import xml.etree.ElementTree as etree
 from pathlib import Path
 from typing import List, Union, cast
 
-from pytiled_parser.properties import Properties, Property
+from pytiled_parser.properties import Properties, Property, ClassProperty
 from pytiled_parser.util import parse_color
 
 
@@ -14,6 +14,13 @@ def parse(raw_properties: etree.Element) -> Properties:
     for raw_property in raw_properties.findall("property"):
 
         type_ = raw_property.attrib.get("type")
+        if type_ == "class":
+            children_nodes = raw_property.find("./properties")
+            x = ClassProperty(
+                raw_property.attrib["propertytype"], parse(children_nodes) if children_nodes is not None else {})
+            final[raw_property.attrib["name"]] = x
+            continue
+
         value_ = raw_property.attrib["value"]
         if type_ == "file":
             value = Path(value_)

--- a/pytiled_parser/parsers/tmx/tiled_map.py
+++ b/pytiled_parser/parsers/tmx/tiled_map.py
@@ -22,7 +22,8 @@ def parse(file: Path) -> TiledMap:
         TiledMap: A parsed TiledMap.
     """
     with open(file) as map_file:
-        raw_map = etree.parse(map_file).getroot()
+        tree = etree.parse(map_file)
+        raw_map = tree.getroot()
 
     parent_dir = file.parent
 
@@ -60,7 +61,7 @@ def parse(file: Path) -> TiledMap:
             )
 
     layers = []
-    for element in raw_map.iter():
+    for element in raw_map.getchildren():
         if element.tag in ["layer", "objectgroup", "imagelayer", "group"]:
             layers.append(parse_layer(element, parent_dir))
 

--- a/pytiled_parser/parsers/tmx/tileset.py
+++ b/pytiled_parser/parsers/tmx/tileset.py
@@ -121,6 +121,7 @@ def parse(
         tile_height=int(raw_tileset.attrib["tileheight"]),
         columns=int(raw_tileset.attrib["columns"]),
         firstgid=firstgid,
+        alignment=raw_tileset.attrib.get("objectalignment", "bottomleft"),
     )
 
     if raw_tileset.attrib.get("version") is not None:

--- a/pytiled_parser/properties.py
+++ b/pytiled_parser/properties.py
@@ -13,6 +13,11 @@ from typing import Dict, Union
 
 from .common_types import Color
 
-Property = Union[float, Path, str, bool, Color]
+class ClassProperty(dict):
+	def __init__(self, propertytype:str, *args, **kwargs):
+		self.propertytype = propertytype or ''
+		dict.__init__(self, *args, **kwargs)
+
+Property = Union[float, Path, str, bool, Color, ClassProperty]
 
 Properties = Dict[str, Property]

--- a/pytiled_parser/tileset.py
+++ b/pytiled_parser/tileset.py
@@ -150,3 +150,4 @@ class Tileset:
     properties: Optional[properties_.Properties] = None
     tiles: Optional[Dict[int, Tile]] = None
     wang_sets: Optional[List[WangSet]] = None
+    alignment: Optional[str] = None


### PR DESCRIPTION
Class properties: These are properties in Tiled that are themselves dicts of additional properties. However, a basic dict cannot be used because class properties also have a "type" that is not a field.
Object alignment: Where the positioning and rotation anchor for a tile object is located.

It looks like you have more code-related commits on `master` than on `development`, so I'm creating this PR for `master`. Let me know if I should do `development` instead.