### PR TITLE
Fix KeyError: 'value' for parsing TMX Map Format

### DIFF
--- a/pytiled_parser/parsers/tmx/properties.py
+++ b/pytiled_parser/parsers/tmx/properties.py
@@ -14,7 +14,7 @@ def parse(raw_properties: etree.Element) -> Properties:
     for raw_property in raw_properties.findall("property"):
 
         type_ = raw_property.attrib.get("type")
-        value_ = raw_property.attrib["value"]
+        value_ = raw_property.attrib.get("value")
         if type_ == "file":
             value = Path(value_)
         elif type_ == "color":


### PR DESCRIPTION
# Problem

KeyError: 'value' when parsing .tmx files.

Tiled version: 1.9.0
pytiled_parser version: 2.1.0

```
Traceback (most recent call last):
  File "./make_map.py", line 11, in <module>
    map = pytiled_parser.parse_map(map_file)
  File "/Users/laqieer/Library/Python/3.8/lib/python/site-packages/pytiled_parser/parser.py", line 25, in parse_map
    return tmx_map_parse(file)  # type: ignore
  File "/Users/laqieer/Library/Python/3.8/lib/python/site-packages/pytiled_parser/parsers/tmx/tiled_map.py", line 65, in parse
    layers.append(parse_layer(element, parent_dir))
  File "/Users/laqieer/Library/Python/3.8/lib/python/site-packages/pytiled_parser/parsers/tmx/layer.py", line 365, in parse
    return _parse_object_layer(raw_layer, parent_dir)
  File "/Users/laqieer/Library/Python/3.8/lib/python/site-packages/pytiled_parser/parsers/tmx/layer.py", line 270, in _parse_object_layer
    objects.append(parse_object(object_, parent_dir))
  File "/Users/laqieer/Library/Python/3.8/lib/python/site-packages/pytiled_parser/parsers/tmx/tiled_object.py", line 294, in parse
    return _parse_tile(raw_object, new_tileset, new_tileset_path)
  File "/Users/laqieer/Library/Python/3.8/lib/python/site-packages/pytiled_parser/parsers/tmx/tiled_object.py", line 156, in _parse_tile
    **_parse_common(raw_object).__dict__
  File "/Users/laqieer/Library/Python/3.8/lib/python/site-packages/pytiled_parser/parsers/tmx/tiled_object.py", line 60, in _parse_common
    common.properties = parse_properties(properties_element)
  File "/Users/laqieer/Library/Python/3.8/lib/python/site-packages/pytiled_parser/parsers/tmx/properties.py", line 18, in parse
    value_ = raw_property.attrib["value"]
KeyError: 'value'
```

# Reason

According to Tiled's [doc](https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#property):
```
Class properties will have their member values stored in a nested <properties> element.
```
In this case, `raw_property.attrib` doesn't have key `value`:
```
{'name': 'unit', 'type': 'class', 'propertytype': 'Unit'}
```

# Solution

This PR use `get()` to get the value of key `value` instead. It avoids the crash when opening the TMX file with `parse_map`, but it cannot get the actual value of Class property. Class property's support for TMX is introduced in https://github.com/pythonarcade/pytiled_parser/pull/56 and reverted in https://github.com/pythonarcade/pytiled_parser/commit/9e8e3b980a6bb8b5d420641f2d64388a06cfb9f5. In contrast, this PR is to fix the possible KeyError here rather than support Class properties.