### PR TITLE
Fix multiline string properties

### DIFF
--- a/pytiled_parser/parsers/tmx/properties.py
+++ b/pytiled_parser/parsers/tmx/properties.py
@@ -12,10 +12,9 @@ def parse(raw_properties: etree.Element) -> Properties:
     for raw_property in raw_properties.findall("property"):
         type_ = raw_property.attrib.get("type")
 
-        if "value" not in raw_property.attrib:
+        value_ = raw_property.attrib.get("value", raw_property.text)
+        if value_ is None:
             continue
-
-        value_ = raw_property.attrib["value"]
 
         if type_ == "file":
             value = Path(value_)

--- a/tests/test_tiled_object_tmx.py
+++ b/tests/test_tiled_object_tmx.py
@@ -129,6 +129,9 @@ RECTANGLES = [
           <property name="float property" type="float" value="42.1"/>
           <property name="int property" type="int" value="8675309"/>
           <property name="string property" value="pytiled_parser rulez!1!!"/>
+          <property name="multiline string property">Hi
+I can write multiple lines in here
+That's pretty great</property>
          </properties>
         </object>
         """,
@@ -144,6 +147,7 @@ RECTANGLES = [
                 "float property": 42.1,
                 "int property": 8675309,
                 "string property": "pytiled_parser rulez!1!!",
+                "multiline string property": "Hi\nI can write multiple lines in here\nThat's pretty great",
             },
         ),
     ),


### PR DESCRIPTION
On Tiled version 1.11.0 (and earlier), string properties spanning multiple lines are supported. Next to the property's value, a "..." button appears which opens a multiline textbox where these strings can be written. [Here](https://files.catbox.moe/8zbu0w.tmx) is a map I created with a multiline string property.

Regular string properties look like this:
```xml
    <property name="description" value="&quot;10 steps to the East - 2nd Sign&quot;"/>
```
Multiline string properties look like this:
```xml
    <property name="description">&quot;10 steps to the East - 3rd Sign
10 steps to the West - 1st Sign&quot;</property>
```
Their contents are stored in the node text, instead of an attribute.

The [documentation](https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#property) also states ([since 2017](https://github.com/mapeditor/tiled/commit/fb1839b41d4797c87e5bb7183209c044fe244714)):
> When a string property contains newlines, the current version of Tiled will write out the value as characters contained inside the `property` element rather than as the `value` attribute. It is possible that a future version of the TMX format will switch to always saving property values inside the element rather than as an attribute.

This pull request fixes this issue, and adds a test for it.